### PR TITLE
Loosen ruby version requirement

### DIFF
--- a/server_sent_events.gemspec
+++ b/server_sent_events.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = "~> 2.1"
+  spec.required_ruby_version = ">= 2.1"
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "pry", "~> 0.11.3"


### PR DESCRIPTION
Trying to upgrade an application to ruby 3.0 where we use this as a dependency. Output from rspec run below.

```ruby
ServerSentEvents
  has a version number
  .listen
    produces event from data
  .create_client
    creates new client
    creates new client with headers

ServerSentEvents::Client
  #listen
    produces event from data

ServerSentEvents::Event
  #set
    sets id field
    sets event field
    sets data field
    apends data to existing content
    ignores unknown key 'selection'
    ignores unknown key 'of'
    ignores unknown key 'bad'
    ignores unknown key 'keys'
    ignores unknown key 'here'
  #to_s
    serializes event
    skips missing id
    skips missing event
    serializes empty event

ServerSentEvents::Parser
  #push
    ignores lines starting with :
    emits events on empty line
    parses single event data
    handles multiline data
    emits multiple events
    waits on partial data
    emits all complete events
    parser events with empty values
    parser events with intermixed fields
    strips leading space if present

Finished in 0.03029 seconds (files took 0.3223 seconds to load)
28 examples, 0 failures

Coverage report generated for RSpec to /Users/mj068550/Documents/Git/server-sent-events-ruby/coverage. 76 / 76 LOC (100.0%) covered.
```